### PR TITLE
Refine sidebar styling and embed behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import AccessTokenComponent from "./components/AccessTokenComponent";
 import CreateConnectorComponent from "./components/CreateConnectorComponent";
 import ReadConnectorComponent from "./components/ReadConnectorComponent";
@@ -8,7 +8,6 @@ import ReadTDMsComponent from "./components/ReadTDMsComponent";
 import ReadUsersComponent from "./components/ReadUsersComponent";
 import CreatePipelineEmbed from "./components/CreatePipelineEmbed";
 import ExecutionListEmbed from "./components/ExecutionListEmbed";
-import PipelineListEmbed from "./components/PipelineListEmbed";
 import PipelineDetailsEmbed from "./components/PipelineDetailsEmbed";
 import FileUploadEmbeddable from "./components/FileUploadEmbeddable";
 import { AuthProvider } from "./auth/AuthContext";
@@ -74,8 +73,6 @@ const App: React.FC = () => {
         return <CreatePipelineEmbed />;
       case "ExecutionList":
         return <ExecutionListEmbed />;
-      case "PipelineList":
-        return <PipelineListEmbed />;
       case "PipelineDetails":
         return <PipelineDetailsEmbed />;
       case "FileUpload":
@@ -140,7 +137,6 @@ const App: React.FC = () => {
               onClick={() => toggleSection("Pipelines")}
               buttons={[
                 { label: "Create", active: activeTab === "CreatePipeline", onClick: () => setActiveTab("CreatePipeline") },
-                { label: "List", active: activeTab === "PipelineList", onClick: () => setActiveTab("PipelineList") },
                 { label: "Details", active: activeTab === "PipelineDetails", onClick: () => setActiveTab("PipelineDetails") },
               ]}
             />
@@ -162,27 +158,12 @@ const App: React.FC = () => {
           </aside>
 
           <main className="main-content">
-            {["CreatePipeline", "PipelineList", "PipelineDetails", "ExecutionList"].includes(activeTab) ? (
+            {["CreatePipeline", "PipelineDetails", "ExecutionList", "FileUpload"].includes(activeTab) ? (
               <div className="embed-container">
                 {renderTabContent()}
               </div>
             ) : (
               <div className="content-box">
-                <h1 className="content-title">
-                  {{
-                    AccessToken: "Access Token",
-                    CreateConnector: "Create Connector",
-                    ReadConnector: "Read Connectors",
-                    DeleteConnector: "Delete Connector",
-                    CreateTDM: "Create TDM",
-                    ReadTDMs: "Read TDMs",
-                    ReadUsers: "Read Users",
-                    CreatePipeline: "Create Pipeline",
-                    PipelineList: "Pipeline List",
-                    PipelineDetails: "Pipeline Details",
-                    ExecutionList: "Execution List",
-                  }[activeTab] || "App"}
-                </h1>
                 {renderTabContent()}
               </div>
             )}

--- a/src/components/CreateConnectorComponent.tsx
+++ b/src/components/CreateConnectorComponent.tsx
@@ -10,8 +10,6 @@ const CreateConnectorComponent: React.FC = () => {
 
   return (
     <div className="component-container">
-      <h2>Create Connector (Embedded)</h2>
-
       <CreateConnector
         accessToken={accessToken || ""}
         configuration={{

--- a/src/components/CreatePipelineEmbed.tsx
+++ b/src/components/CreatePipelineEmbed.tsx
@@ -10,7 +10,6 @@ const CreatePipelineEmbed: React.FC = () => {
   if (!accessToken) {
     return (
       <div className="component-container">
-        <h2>Create Pipeline (Embedded)</h2>
         <p style={{ color: "#fff" }}>
           Please authenticate first to create a pipeline.
         </p>
@@ -20,20 +19,17 @@ const CreatePipelineEmbed: React.FC = () => {
 
   return (
     <div className="component-container">
-      <h2>Create Pipeline (Embedded)</h2>
-      <div className="embed-container">
-        <CreatePipeline
-          accessToken={accessToken}
-          configuration={{
-            tdmId: "68a38fe6ba7ddf8a13335f6b",
-            outputConnectorId: "683054fd65dd47b2d44f4524",
-          }}
-          settings={{
-            modal: true,
-            runPipelineOnCreation: true
-          }}
-        />
-      </div>
+      <CreatePipeline
+        accessToken={accessToken}
+        configuration={{
+          tdmId: "68a38fe6ba7ddf8a13335f6b",
+          outputConnectorId: "683054fd65dd47b2d44f4524",
+        }}
+        settings={{
+          modal: false,
+          runPipelineOnCreation: true,
+        }}
+      />
     </div>
   );
 };

--- a/src/components/ExecutionDetailsEmbed.tsx
+++ b/src/components/ExecutionDetailsEmbed.tsx
@@ -9,10 +9,10 @@ const ExecutionDetailsEmbed: React.FC = () => {
 
   return (
     <div className="component-container">
-      <h2>Execution Details (Embedded)</h2>
-      <div className="embed-container">
-        <ExecutionDetails accessToken={accessToken || ""} />
-      </div>
+      <ExecutionDetails
+        accessToken={accessToken || ""}
+        settings={{ modal: false }}
+      />
     </div>
   );
 };

--- a/src/components/ExecutionListEmbed.tsx
+++ b/src/components/ExecutionListEmbed.tsx
@@ -105,7 +105,6 @@ const ExecutionListEmbed: React.FC = () => {
   if (!accessToken) {
     return (
       <div className="component-container">
-        <h2>Execution Viewer</h2>
         <p style={{ color: "#fff" }}>Please authenticate first.</p>
       </div>
     );
@@ -113,7 +112,6 @@ const ExecutionListEmbed: React.FC = () => {
 
   return (
     <div className="component-container">
-      <h2>Execution Viewer</h2>
       {error && <div className="error-box">{error}</div>}
 
       {!selectedPipeline && !selectedExecution && (
@@ -210,13 +208,11 @@ const ExecutionListEmbed: React.FC = () => {
           >
             ← Back to Executions
           </button>
-          <div className="embed-container">
-            <ExecutionDetails
-              accessToken={accessToken}
-              executionId={selectedExecution.id}
-              settings={{ modal: false }}
-            />
-          </div>
+          <ExecutionDetails
+            accessToken={accessToken}
+            executionId={selectedExecution.id}
+            settings={{ modal: false }}
+          />
         </>
       )}
     </div>

--- a/src/components/FileUploadEmbeddable.tsx
+++ b/src/components/FileUploadEmbeddable.tsx
@@ -34,7 +34,6 @@ const FileUploadEmbeddable: React.FC = () => {
 
     return (
         <div className="component-container">
-            <h2>File Upload Embeddable</h2>
             {error && <div className="error-box">{error}</div>}
             <div className="form">
                 <label htmlFor="connector-select" style={{ fontWeight: 600, marginBottom: 8 }}>
@@ -63,7 +62,7 @@ const FileUploadEmbeddable: React.FC = () => {
                         settings={{
                             i18nOverrides: {},
                             language: "en",
-                            modal: true,
+                            modal: false,
                             allowedFileTypes: ["csv", "tsv", "xls", "xlsx", "json", "xml"],
                         }}
                         onExecutionView={({ execution }) => {

--- a/src/components/PipelineDetailsEmbed.tsx
+++ b/src/components/PipelineDetailsEmbed.tsx
@@ -15,16 +15,6 @@ const PipelineDetailsEmbed: React.FC = () => {
   );
   const [error, setError] = useState<string | null>(null);
 
-  const handleTokenSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!accessToken.trim()) {
-      setError("Please enter a valid access token.");
-      return;
-    }
-    setError(null);
-    setTokenReady(true);
-  };
-
   const handlePipelineSelect = ({ data }: { data: PipelineData }) => {
     if (data && data.id) {
       setSelectedPipelineId(data.id);
@@ -38,7 +28,7 @@ const PipelineDetailsEmbed: React.FC = () => {
   const renderContent = () => {
     if (selectedPipelineId) {
       return (
-        <div className="embed-container">
+        <div>
           <button
             onClick={handleBackToList}
             className="button"
@@ -49,23 +39,22 @@ const PipelineDetailsEmbed: React.FC = () => {
           <PipelineDetails
             accessToken={accessToken || ""}
             pipelineId={selectedPipelineId}
+            settings={{ modal: false }}
           />
         </div>
       );
     }
     return (
-      <div className="embed-container">
-        <PipelineList
-          accessToken={accessToken || ""}
-          onPipelineView={handlePipelineSelect}
-        />
-      </div>
+      <PipelineList
+        accessToken={accessToken || ""}
+        onPipelineView={handlePipelineSelect}
+        settings={{ modal: false }}
+      />
     );
   };
 
   return (
     <div className="component-container">
-      <h2>Pipeline Details (Embedded)</h2>
       {error && <div className="error-box">{error}</div>}
       {renderContent()}
     </div>

--- a/src/components/PipelineListEmbed.tsx
+++ b/src/components/PipelineListEmbed.tsx
@@ -9,10 +9,10 @@ const PipelineListEmbed: React.FC = () => {
 
   return (
     <div className="component-container">
-      <h2>Pipeline List (Embedded)</h2>
-      <div className="embed-container">
-        <PipelineList accessToken={accessToken || ""} />
-      </div>
+      <PipelineList
+        accessToken={accessToken || ""}
+        settings={{ modal: false }}
+      />
     </div>
   );
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -118,11 +118,21 @@ body {
   justify-content: center;
 }
 
-.sidebar-button.active,
 .sidebar-button:hover {
-  background: var(--nuvo-blue);
+  background: var(--nuvo-light-gray);
+  color: var(--nuvo-dark-blue);
+}
+
+.sidebar-button.active {
+  background: #1152d5;
   color: var(--nuvo-white);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.sidebar-submenu .sidebar-button:hover,
+.sidebar-submenu .sidebar-button.active {
+  background: #f5f8fe;
+  color: #1957d5;
 }
 
 .sidebar-section {
@@ -154,9 +164,13 @@ body {
   justify-content: center;
 }
 
-.sidebar-section-toggle.open,
 .sidebar-section-toggle:hover {
-  background: var(--nuvo-blue);
+  background: var(--nuvo-light-gray);
+  color: var(--nuvo-dark-blue);
+}
+
+.sidebar-section-toggle.open {
+  background: #1152d5;
   color: var(--nuvo-white);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
@@ -195,7 +209,7 @@ body {
 .component-container h1,
 .component-container h2,
 .component-container h3 {
-  color: var(--nuvo-white);
+  color: var(--nuvo-dark-blue);
 }
 
 h1.component-title {
@@ -370,7 +384,11 @@ h1.component-title {
 
 .embed-container {
   width: 100%;
+  max-width: 900px;
   box-sizing: border-box;
+  background-color: var(--nuvo-white);
+  padding: 48px 40px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.07);
 }
 
 .sidebar-logo-container {


### PR DESCRIPTION
## Summary
- Restyle sidebar hover/active states and sub-item colors
- Render embedded components within white containers and drop extra titles
- Remove unused pipeline list from navigation and ensure embeddables run non-modally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68a39ca971588326add322c04253d6f1