### PR TITLE
Add connector and target data model embeds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,10 @@ import CreatePipelineEmbed from "./components/CreatePipelineEmbed";
 import ExecutionListEmbed from "./components/ExecutionListEmbed";
 import PipelineDetailsEmbed from "./components/PipelineDetailsEmbed";
 import FileUploadEmbeddable from "./components/FileUploadEmbeddable";
+import ConnectorListEmbed from "./components/ConnectorListEmbed";
+import ConnectorDetailsEmbed from "./components/ConnectorDetailsEmbed";
+import TargetDataModelListEmbed from "./components/TargetDataModelListEmbed";
+import TargetDataModelDetailsEmbed from "./components/TargetDataModelDetailsEmbed";
 import { AuthProvider } from "./auth/AuthContext";
 import AuthModal from "./auth/AuthModal";
 
@@ -77,6 +81,14 @@ const App: React.FC = () => {
         return <PipelineDetailsEmbed />;
       case "FileUpload":
         return <FileUploadEmbeddable />;
+      case "ConnectorList":
+        return <ConnectorListEmbed />;
+      case "ConnectorDetails":
+        return <ConnectorDetailsEmbed />;
+      case "TargetDataModelList":
+        return <TargetDataModelListEmbed />;
+      case "TargetDataModelDetails":
+        return <TargetDataModelDetailsEmbed />;
       default:
         return null;
     }
@@ -112,6 +124,8 @@ const App: React.FC = () => {
                 { label: "Create", active: activeTab === "CreateConnector", onClick: () => setActiveTab("CreateConnector") },
                 { label: "Read", active: activeTab === "ReadConnector", onClick: () => setActiveTab("ReadConnector") },
                 { label: "Delete", active: activeTab === "DeleteConnector", onClick: () => setActiveTab("DeleteConnector") },
+                { label: "List", active: activeTab === "ConnectorList", onClick: () => setActiveTab("ConnectorList") },
+                { label: "Details", active: activeTab === "ConnectorDetails", onClick: () => setActiveTab("ConnectorDetails") },
               ]}
             />
 
@@ -122,6 +136,8 @@ const App: React.FC = () => {
               buttons={[
                 { label: "Create", active: activeTab === "CreateTDM", onClick: () => setActiveTab("CreateTDM") },
                 { label: "Read", active: activeTab === "ReadTDMs", onClick: () => setActiveTab("ReadTDMs") },
+                { label: "List", active: activeTab === "TargetDataModelList", onClick: () => setActiveTab("TargetDataModelList") },
+                { label: "Details", active: activeTab === "TargetDataModelDetails", onClick: () => setActiveTab("TargetDataModelDetails") },
               ]}
             />
 
@@ -158,7 +174,7 @@ const App: React.FC = () => {
           </aside>
 
           <main className="main-content">
-            {["CreatePipeline", "PipelineDetails", "ExecutionList", "FileUpload"].includes(activeTab) ? (
+            {["CreatePipeline", "PipelineDetails", "ExecutionList", "FileUpload", "ConnectorList", "ConnectorDetails", "TargetDataModelList", "TargetDataModelDetails"].includes(activeTab) ? (
               <div className="embed-container">
                 {renderTabContent()}
               </div>

--- a/src/components/ConnectorDetailsEmbed.tsx
+++ b/src/components/ConnectorDetailsEmbed.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { ConnectorDetails, ConnectorList } from "@getnuvo/pipelines-react";
+import { useAuth } from "../auth/AuthContext";
+import "@getnuvo/pipelines-react/index.css";
+import "../styles.css";
+
+interface ConnectorData {
+  id: string;
+}
+
+const ConnectorDetailsEmbed: React.FC = () => {
+  const { accessToken } = useAuth();
+  const [selectedConnectorId, setSelectedConnectorId] = useState<string | null>(null);
+
+  return (
+    <div className="component-container">
+      {selectedConnectorId ? (
+        <div>
+          <button
+            className="button"
+            onClick={() => setSelectedConnectorId(null)}
+            style={{ marginBottom: "1rem", alignSelf: "flex-start" }}
+          >
+            ← Back to List
+          </button>
+          <ConnectorDetails
+            accessToken={accessToken || ""}
+            connectorId={selectedConnectorId}
+            settings={{ language: "en", modal: false }}
+            onConnectorUpdate={({ data }: { data: unknown }) => {
+              console.log("Connector updated:", data);
+            }}
+            onConnectorDelete={({ data }: { data: unknown }) => {
+              console.log("Connector deleted:", data);
+              setSelectedConnectorId(null);
+            }}
+            onClose={() => setSelectedConnectorId(null)}
+          />
+        </div>
+      ) : (
+        <ConnectorList
+          accessToken={accessToken || ""}
+          settings={{ language: "en", modal: false, allowConnectorCreation: false }}
+          onConnectorView={({ data }: { data: ConnectorData }) => {
+            setSelectedConnectorId(data.id);
+          }}
+          onClose={() => {
+            console.log("Connector list closed");
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ConnectorDetailsEmbed;
+

--- a/src/components/ConnectorListEmbed.tsx
+++ b/src/components/ConnectorListEmbed.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { ConnectorList } from "@getnuvo/pipelines-react";
+import { useAuth } from "../auth/AuthContext";
+import "@getnuvo/pipelines-react/index.css";
+import "../styles.css";
+
+const ConnectorListEmbed: React.FC = () => {
+  const { accessToken } = useAuth();
+
+  return (
+    <div className="component-container">
+      <ConnectorList
+        accessToken={accessToken || ""}
+        settings={{ language: "en", modal: false, allowConnectorCreation: false }}
+        onConnectorView={({ data }: { data: unknown }) => {
+          console.log("Connector selected:", data);
+        }}
+        onConnectorCreate={() => {
+          console.log("Connector creation triggered");
+        }}
+        onClose={() => {
+          console.log("Connector list closed");
+        }}
+      />
+    </div>
+  );
+};
+
+export default ConnectorListEmbed;
+

--- a/src/components/TargetDataModelDetailsEmbed.tsx
+++ b/src/components/TargetDataModelDetailsEmbed.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { TargetDataModelDetails, TargetDataModelList } from "@getnuvo/pipelines-react";
+import { useAuth } from "../auth/AuthContext";
+import "@getnuvo/pipelines-react/index.css";
+import "../styles.css";
+
+interface TdmData {
+  id: string;
+}
+
+const TargetDataModelDetailsEmbed: React.FC = () => {
+  const { accessToken } = useAuth();
+  const [selectedTdmId, setSelectedTdmId] = useState<string | null>(null);
+
+  return (
+    <div className="component-container">
+      {selectedTdmId ? (
+        <div>
+          <button
+            className="button"
+            onClick={() => setSelectedTdmId(null)}
+            style={{ marginBottom: "1rem", alignSelf: "flex-start" }}
+          >
+            ← Back to List
+          </button>
+          <TargetDataModelDetails
+            accessToken={accessToken || ""}
+            targetDataModelId={selectedTdmId}
+            settings={{ language: "en", modal: false }}
+            onTargetDataModelUpdate={({ data }: { data: unknown }) => {
+              console.log("TDM updated:", data);
+            }}
+            onTargetDataModelDelete={({ data }: { data: unknown }) => {
+              console.log("TDM deleted:", data);
+              setSelectedTdmId(null);
+            }}
+            onClose={() => setSelectedTdmId(null)}
+          />
+        </div>
+      ) : (
+        <TargetDataModelList
+          accessToken={accessToken || ""}
+          settings={{ language: "en", modal: false, allowTargetDataModelCreation: false }}
+          onTargetDataModelView={({ data }: { data: TdmData }) => {
+            setSelectedTdmId(data.id);
+          }}
+          onClose={() => {
+            console.log("TDM list closed");
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TargetDataModelDetailsEmbed;
+

--- a/src/components/TargetDataModelListEmbed.tsx
+++ b/src/components/TargetDataModelListEmbed.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { TargetDataModelList } from "@getnuvo/pipelines-react";
+import { useAuth } from "../auth/AuthContext";
+import "@getnuvo/pipelines-react/index.css";
+import "../styles.css";
+
+const TargetDataModelListEmbed: React.FC = () => {
+  const { accessToken } = useAuth();
+
+  return (
+    <div className="component-container">
+      <TargetDataModelList
+        accessToken={accessToken || ""}
+        settings={{ language: "en", modal: false, allowTargetDataModelCreation: false }}
+        onTargetDataModelView={({ data }: { data: unknown }) => {
+          console.log("TDM selected:", data);
+        }}
+        onTargetDataModelCreate={() => {
+          console.log("TDM creation triggered");
+        }}
+        onClose={() => {
+          console.log("TDM list closed");
+        }}
+      />
+    </div>
+  );
+};
+
+export default TargetDataModelListEmbed;
+


### PR DESCRIPTION
## Summary
- add ConnectorListEmbed and ConnectorDetailsEmbed components
- add TargetDataModelListEmbed and TargetDataModelDetailsEmbed components
- wire new embeddables into application sidebar and routing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a82d093de4832693ebf0f23977f0d5