### PR TITLE
Fix auth token flow and expose session info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.DS_Store
+.yarn/
+.yarnrc.yml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import ConnectorListEmbed from "./components/ConnectorListEmbed";
 import ConnectorDetailsEmbed from "./components/ConnectorDetailsEmbed";
 import TargetDataModelListEmbed from "./components/TargetDataModelListEmbed";
 import TargetDataModelDetailsEmbed from "./components/TargetDataModelDetailsEmbed";
-import { AuthProvider } from "./auth/AuthContext";
+import { useAuth } from "./auth/AuthContext";
 import AuthModal from "./auth/AuthModal";
 
 import "./styles.css";
@@ -47,9 +47,9 @@ const SidebarSection: React.FC<{
 );
 
 const App: React.FC = () => {
+  const { accessToken, userName } = useAuth();
   const [activeTab, setActiveTab] = useState("AccessToken");
   const [openSection, setOpenSection] = useState<string | null>(null);
-  const [authenticated, setAuthenticated] = useState(false);
 
   // Removed code that forcibly hides parts of the embedded pipeline component
 
@@ -94,14 +94,21 @@ const App: React.FC = () => {
     }
   };
 
+  if (!accessToken) {
+    return <AuthModal />;
+  }
+
+  const handleCopyToken = () => {
+    navigator.clipboard.writeText(accessToken);
+  };
+
   return (
-    <AuthProvider>
-      {!authenticated && (
-        <AuthModal onAuthenticated={() => setAuthenticated(true)} />
-      )}
-      {authenticated && (
-        <div className="app-container">
-          <aside className="sidebar">
+    <div className="app-container">
+      <div className="top-bar">
+        <span className="user-name">{userName}</span>
+        <button className="button copy-token-button" onClick={handleCopyToken}>Copy Token</button>
+      </div>
+      <aside className="sidebar">
             <div className="sidebar-logo-container">
               <img
                 src="src/public/Logo_Darkblue.svg"
@@ -171,9 +178,9 @@ const App: React.FC = () => {
               onClick={() => setActiveTab("FileUpload")}
               label="File Upload"
             />
-          </aside>
+      </aside>
 
-          <main className="main-content">
+      <main className="main-content">
             {["CreatePipeline", "PipelineDetails", "ExecutionList", "FileUpload", "ConnectorList", "ConnectorDetails", "TargetDataModelList", "TargetDataModelDetails"].includes(activeTab) ? (
               <div className="embed-container">
                 {renderTabContent()}
@@ -183,10 +190,8 @@ const App: React.FC = () => {
                 {renderTabContent()}
               </div>
             )}
-          </main>
-        </div>
-      )}
-    </AuthProvider>
+      </main>
+    </div>
   );
 };
 

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -3,16 +3,23 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 type AuthContextType = {
     accessToken: string | null;
     setAccessToken: (token: string) => void;
+    userName: string | null;
+    setUserName: (name: string) => void;
 };
 
 const AuthContext = createContext<AuthContextType>({
     accessToken: null,
     setAccessToken: () => { },
+    userName: null,
+    setUserName: () => { },
 });
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const [accessToken, setAccessTokenState] = useState<string | null>(() => {
         return localStorage.getItem('accessToken');
+    });
+    const [userName, setUserNameState] = useState<string | null>(() => {
+        return localStorage.getItem('userName');
     });
 
     useEffect(() => {
@@ -23,12 +30,24 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         }
     }, [accessToken]);
 
+    useEffect(() => {
+        if (userName) {
+            localStorage.setItem('userName', userName);
+        } else {
+            localStorage.removeItem('userName');
+        }
+    }, [userName]);
+
     const setAccessToken = (token: string) => {
         setAccessTokenState(token);
     };
 
+    const setUserName = (name: string) => {
+        setUserNameState(name);
+    };
+
     return (
-        <AuthContext.Provider value={{ accessToken, setAccessToken }}>
+        <AuthContext.Provider value={{ accessToken, setAccessToken, userName, setUserName }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/auth/AuthModal.tsx
+++ b/src/auth/AuthModal.tsx
@@ -1,29 +1,26 @@
 import React, { useState } from 'react';
 import { useAuth } from './AuthContext';
 
-type Props = {
-    onAuthenticated: () => void;
-};
-
 const mockFetchAccessToken = async (email: string, licenseKey: string) => {
     // Replace with real API call
     return Promise.resolve('mocked_access_token');
 };
 
-const AuthModal: React.FC<Props> = ({ onAuthenticated }) => {
-    const { setAccessToken } = useAuth();
+const AuthModal: React.FC = () => {
+    const { setAccessToken, setUserName } = useAuth();
     const [mode, setMode] = useState<'token' | 'license'>('token');
     const [accessToken, setAccessTokenInput] = useState('');
+    const [name, setName] = useState('');
     const [email, setEmail] = useState('');
     const [licenseKey, setLicenseKey] = useState('');
     const [error, setError] = useState('');
 
     const handleTokenSubmit = () => {
-        if (accessToken.trim()) {
+        if (accessToken.trim() && name.trim()) {
             setAccessToken(accessToken.trim());
-            onAuthenticated();
+            setUserName(name.trim());
         } else {
-            setError('Please enter a valid access token.');
+            setError('Please enter a name and access token.');
         }
     };
 
@@ -32,7 +29,7 @@ const AuthModal: React.FC<Props> = ({ onAuthenticated }) => {
             try {
                 const token = await mockFetchAccessToken(email, licenseKey);
                 setAccessToken(token);
-                onAuthenticated();
+                setUserName(email.trim());
             } catch {
                 setError('Failed to authenticate with email and license key.');
             }
@@ -57,6 +54,13 @@ const AuthModal: React.FC<Props> = ({ onAuthenticated }) => {
                 </div>
                 {mode === 'token' ? (
                     <div className="auth-form">
+                        <input
+                            className="input"
+                            type="text"
+                            placeholder="Name"
+                            value={name}
+                            onChange={e => setName(e.target.value)}
+                        />
                         <input
                             className="input"
                             type="text"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./auth/AuthContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,10 +47,11 @@ body {
 
 /* Main Layout */
 .app-container {
-  display: flex;
-  min-height: 100vh;
-  width: 100%;
-  background-color: var(--nuvo-dark-blue);
+    display: flex;
+    min-height: 100vh;
+    width: 100%;
+    background-color: var(--nuvo-dark-blue);
+    position: relative;
 }
 
 .main-content {
@@ -60,6 +61,21 @@ body {
   justify-content: center;
   align-items: flex-start;
   background-color: var(--nuvo-dark-blue);
+}
+
+/* Top bar with user info */
+.top-bar {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.user-name {
+  color: var(--nuvo-white);
+  font-weight: 700;
 }
 
 .content-box {


### PR DESCRIPTION
## Summary
- ensure access token from either login method is provided to components by rendering the app only after a token is present
- track the user's name alongside the access token and display both in a new top-right session bar with a copy token button
- move auth provider to root and persist user details in local storage

## Testing
- `yarn build` *(fails: Failed to resolve entry for package "tabbable"; attempted to install but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a86369a0f083268e3fd707a7bfa199